### PR TITLE
A fix to property injection with binding where auto is turned off.

### DIFF
--- a/src/com/creativebottle/starlingmvc/binding/Bindings.as
+++ b/src/com/creativebottle/starlingmvc/binding/Bindings.as
@@ -27,12 +27,16 @@ package com.creativebottle.starlingmvc.binding
 
 		public function invalidate(instance:Object, propertyName:String):void
 		{
-			var binding:Binding = getBinding(instance, propertyName);
-			var alreadyInvalidated:Boolean = invalidated.indexOf(binding) != -1;
-
-			if (binding && !alreadyInvalidated)
+			var applicableBindings:Array = getBindings(instance, propertyName);
+			for (var i:uint = 0; i < applicableBindings.length; i++)
 			{
-				invalidated.push(binding);
+				var binding:Binding = applicableBindings[i];
+				var alreadyInvalidated:Boolean = invalidated.indexOf(binding) != -1;
+				
+				if (binding && !alreadyInvalidated)
+				{
+					invalidated.push(binding);
+				}
 			}
 		}
 
@@ -130,18 +134,19 @@ package com.creativebottle.starlingmvc.binding
 				invalidated.splice(i, 1);
 			}
 		}
-
-		private function getBinding(instance:Object, propertyName:String):Binding
+		
+		private function getBindings(instance:Object, propertyName:String):Array
 		{
+			var applicableBindings:Array = new Array();
 			for each (var binding:Binding in bindings)
 			{
 				if (binding.fromTarget == instance && binding.fromPropertyName == propertyName)
 				{
-					return binding;
+					applicableBindings[applicableBindings.length] = binding;
 				}
 			}
-
-			return null;
+			
+			return bindings;
 		}
 
 		private function bindingExists(bindingIn:Binding):Boolean


### PR DESCRIPTION
...e. Essentially such a binding can't be injected multiple times. So if you have a bean with a specific property that you'd like to have injected into two other beans with binding but not automatic binding, then things start breaking. For example, the following would not work:

public class AppData {

```
[Bindings]
public var bindings:Bindings

private var _value:String;

public function get value():String {
    return _value;
}

public function set value(value:String):void {
    _value = value;
    bindings.invalidate(this, "value");
}
```

}

public class BeanToUpdate1 {

```
private var _value:String;

public function get value():String {
    return _value;
}

[Inject(source="appData.value", bind="true", auto="false")]
public function set value(value:String):void {
    _value = value;
}
```

}

public class BeanToUpdate2 {

```
private var _value:String;

public function get value():String {
    return _value;
}

[Inject(source="appData.value", bind="true", auto="false")]
public function set value(value:String):void {
    _value = value;
}
```

}

It would update value in BeanToUpdate1 or in BeanToUpdate2, but not in both. This code fixes the issue.
